### PR TITLE
Use LAS codes

### DIFF
--- a/pymccrgb/core.py
+++ b/pymccrgb/core.py
@@ -46,7 +46,8 @@ def classify_ground_mcc(data, scale, tol, downsample=False):
 
     Returns
     -------
-        An n x 1 array of point class labels. 1 is ground, and 0 is nonground.
+        An n x 1 array of point class labels. By default, 1 is ground,
+        and 0 is nonground.
     """
 
     if downsample:
@@ -63,6 +64,7 @@ def mcc(
     scales=[0.5, 1, 1.5],
     tols=[0.3, 0.3, 0.3],
     threshs=[1, 0.1, 0.01],
+    use_las=False,
     verbose=False,
 ):
     """ Classifies ground points using the MCC algorithm
@@ -98,6 +100,10 @@ def mcc(
         threshs: list
             The convergence thresholds as percentages. Defaults to
             [1%, 0.1%, 0.01%]
+
+        use_las: bool
+           If True, return LAS 1.4 classification codes (2 = ground,
+           4 = medium vegetation). Default False.
 
     Returns
     -------
@@ -148,6 +154,10 @@ def mcc(
             )
         )
 
+    if use_las:
+        labels[labels == 0] = 4  # Vegetation
+        labels[labels == 1] = 2  # Ground
+
     return data, labels
 
 
@@ -162,6 +172,7 @@ def mcc_rgb(
     max_iter=20,
     n_jobs=1,
     seed=None,
+    use_las=False,
     verbose=False,
     **pipeline_kwargs,
 ):
@@ -213,6 +224,10 @@ def mcc_rgb(
 
         seed: int
             Optional seed value for selecting training data.
+
+        use_las: bool
+           If True, return LAS 1.4 classification codes (2 = ground,
+           4 = medium vegetation). Default False.
 
     Returns
     -------
@@ -365,5 +380,9 @@ def mcc_rgb(
                 n_ground, 100 * (n_ground / n_points)
             )
         )
+
+    if use_las:
+        labels[labels == 0] = 4  # Vegetation
+        labels[labels == 1] = 2  # Ground
 
     return data, labels  # , updated

--- a/pymccrgb/core.py
+++ b/pymccrgb/core.py
@@ -64,7 +64,7 @@ def mcc(
     scales=[0.5, 1, 1.5],
     tols=[0.3, 0.3, 0.3],
     threshs=[1, 0.1, 0.01],
-    use_las=False,
+    use_las_codes=False,
     verbose=False,
 ):
     """ Classifies ground points using the MCC algorithm
@@ -101,7 +101,7 @@ def mcc(
             The convergence thresholds as percentages. Defaults to
             [1%, 0.1%, 0.01%]
 
-        use_las: bool
+        use_las_codes: bool
            If True, return LAS 1.4 classification codes (2 = ground,
            4 = medium vegetation). Default False.
 
@@ -154,7 +154,7 @@ def mcc(
             )
         )
 
-    if use_las:
+    if use_las_codes:
         labels[labels == 0] = 4  # Vegetation
         labels[labels == 1] = 2  # Ground
 
@@ -172,7 +172,7 @@ def mcc_rgb(
     max_iter=20,
     n_jobs=1,
     seed=None,
-    use_las=False,
+    use_las_codes=False,
     verbose=False,
     **pipeline_kwargs,
 ):
@@ -225,7 +225,7 @@ def mcc_rgb(
         seed: int
             Optional seed value for selecting training data.
 
-        use_las: bool
+        use_las_codes: bool
            If True, return LAS 1.4 classification codes (2 = ground,
            4 = medium vegetation). Default False.
 
@@ -381,7 +381,7 @@ def mcc_rgb(
             )
         )
 
-    if use_las:
+    if use_las_codes:
         labels[labels == 0] = 4  # Vegetation
         labels[labels == 1] = 2  # Ground
 

--- a/pymccrgb/tests/test_core.py
+++ b/pymccrgb/tests/test_core.py
@@ -56,6 +56,27 @@ class MCCTestCase(unittest.TestCase):
             "Classification is incorrect for default MCC configuration",
         )
 
+    def test_mcc_default_las_codes(self):
+        test_points, test_labels = pymccrgb.core.mcc(self.data,
+                                                     verbose=True,
+                                                     use_las_codes=True)
+        true_points, true_labels = np.load(
+            os.path.join(TEST_OUTPUT_DIR, f"ground_labels_mcc_default.npy"),
+            allow_pickle=True,
+        )
+        self.assertTrue(
+            np.allclose(test_points, true_points),
+            "Ground points are incorrect for default MCC configuration using LAS codes",
+        )
+
+        true_labels[true_labels == 0] = 4
+        true_labels[true_labels == 1] = 2
+
+        self.assertSequenceEqual(
+            test_labels.tolist(),
+            true_labels.tolist(),
+            "Classification is incorrect for default MCC configuration using LAS codes",
+        )
 
 class MCCRGBTestCase(unittest.TestCase):
     def setUp(self):
@@ -79,6 +100,29 @@ class MCCRGBTestCase(unittest.TestCase):
             test_labels.tolist(),
             true_labels.tolist(),
             "Classification is incorrect for default MCC-RGB configuration",
+        )
+
+    def test_mcc_default_las_codes(self):
+        test_points, test_labels = pymccrgb.core.mcc_rgb(self.data,
+                                                         seed=SEED_VALUE,
+                                                         verbose=True,
+                                                         use_las_codes=True)
+        true_points, true_labels = np.load(
+            os.path.join(TEST_OUTPUT_DIR, f"ground_labels_mccrgb_default.npy"),
+            allow_pickle=True,
+        )
+        self.assertTrue(
+            np.allclose(test_points, true_points),
+            "Ground points are incorrect for default MCC configuration using LAS codes",
+        )
+
+        true_labels[true_labels == 0] = 4
+        true_labels[true_labels == 1] = 2
+
+        self.assertSequenceEqual(
+            test_labels.tolist(),
+            true_labels.tolist(),
+            "Classification is incorrect for default MCC configuration using LAS codes",
         )
 
     def test_mcc_rgb_default_parallel(self):


### PR DESCRIPTION
Adds a `use_las_codes` keyword argument to `mcc` and `mcc_rgb`.

With `use_las_codes=True`, 2 is used for ground points and 4 for (medium) vegetation points in the `labels` output array consistent with LAS 1.4 standard.

Closes #28 